### PR TITLE
fix(spread): SpreadReconcileRefreshLabel has a typo

### DIFF
--- a/controller/lifecycle/spread.go
+++ b/controller/lifecycle/spread.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openmfp/golang-commons/logger"
 )
 
-const SpreadReconcileRefreshLabel = "openmfp.io/refesh-reconcile"
+const SpreadReconcileRefreshLabel = "openmfp.io/refresh-reconcile"
 
 // WithSpreadingReconciles sets the LifecycleManager to spread out the reconciles
 func (l *LifecycleManager) WithSpreadingReconciles() *LifecycleManager {
@@ -34,7 +34,7 @@ func getNextReconcileTime() time.Duration {
 // onNextReconcile is a helper function to set the next reconcile time and return the requeueAfter time
 func onNextReconcile(instanceStatusObj RuntimeObjectSpreadReconcileStatus, logger *logger.Logger) (ctrl.Result, error) {
 	requeueAfter := time.Until(instanceStatusObj.GetNextReconcileTime().Time.UTC())
-	logger.Debug().Int64("minutes-till-next-execution", int64(requeueAfter.Minutes())).Msg("Completed reconiliation, no processing needed")
+	logger.Debug().Int64("minutes-till-next-execution", int64(requeueAfter.Minutes())).Msg("Completed reconciliation, no processing needed")
 	return ctrl.Result{RequeueAfter: requeueAfter}, nil
 }
 

--- a/controller/lifecycle/spread_test.go
+++ b/controller/lifecycle/spread_test.go
@@ -12,17 +12,17 @@ import (
 )
 
 func TestGetNextReconcilationTime(t *testing.T) {
-	expectedEaliest := 12 * time.Hour
+	expectedEarliest := 12 * time.Hour
 	expectedLatest := 24 * time.Hour
 
 	actual := getNextReconcileTime()
-	if actual < expectedEaliest || actual > expectedLatest {
-		t.Errorf("Expected time between %v and %v, but got %v", expectedEaliest, expectedLatest, actual)
+	if actual < expectedEarliest || actual > expectedLatest {
+		t.Errorf("Expected time between %v and %v, but got %v", expectedEarliest, expectedLatest, actual)
 	}
 
 	actual2 := getNextReconcileTime()
-	if actual2 < expectedEaliest || actual2 > expectedLatest {
-		t.Errorf("Expected time between %v and %v, but got %v", expectedEaliest, expectedLatest, actual)
+	if actual2 < expectedEarliest || actual2 > expectedLatest {
+		t.Errorf("Expected time between %v and %v, but got %v", expectedEarliest, expectedLatest, actual)
 	}
 
 	if actual == actual2 {


### PR DESCRIPTION
fix(spread): SpreadReconcileRefreshLabel has a typo

Bonus: fix other typos