### PR TITLE
feat: Initializing the logger on lifecycle manager initialization

### DIFF
--- a/controller/lifecycle/lifecycle.go
+++ b/controller/lifecycle/lifecycle.go
@@ -46,12 +46,9 @@ type Subroutine interface {
 	Finalizers() []string
 }
 
-func NewLifecycleManager(ctx context.Context, operatorName string, controllerName string, client client.Client, subroutines []Subroutine) *LifecycleManager {
-	log := logger.NewFromZerolog(logger.LoadLoggerFromContext(ctx).
-		With().
-		Str("operator", operatorName).
-		Str("controller", controllerName).Logger())
+func NewLifecycleManager(log *logger.Logger, operatorName string, controllerName string, client client.Client, subroutines []Subroutine) *LifecycleManager {
 
+	log = log.MustChildLoggerWithAttributes("operator", operatorName, "controller", controllerName)
 	return &LifecycleManager{
 		log:              log,
 		client:           client,
@@ -68,14 +65,19 @@ func (l *LifecycleManager) Reconcile(ctx context.Context, req ctrl.Request, inst
 
 	result := ctrl.Result{}
 	reconcileId := uuid.New().String()
-	log := logger.NewFromZerolog(l.log.With().Str("name", req.Name).Str("namespace", req.Namespace).Str("reconcile_id", reconcileId).Logger())
+
+	log, err := l.log.ChildLoggerWithAttributes("name", req.Name, "namespace", req.Namespace, "reconcile_id", reconcileId)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	sentryTags := sentry.Tags{"namespace": req.Namespace, "name": req.Name}
 
 	ctx = logger.SetLoggerInContext(ctx, log)
 	ctx = sentry.ContextWithSentryTags(ctx, sentryTags)
 
 	log.Info().Msg("start reconcile")
-	err := l.client.Get(ctx, req.NamespacedName, instance)
+	err = l.client.Get(ctx, req.NamespacedName, instance)
 	if err != nil {
 		if k8sErrors.IsNotFound(err) {
 			log.Info().Msg("instance not found. It was likely deleted")
@@ -172,7 +174,7 @@ func containsFinalizer(o client.Object, subroutineFinalizers []string) bool {
 }
 
 func (l *LifecycleManager) reconcileSubroutine(ctx context.Context, instance RuntimeObject, subroutine Subroutine, log *logger.Logger, sentryTags map[string]string) (ctrl.Result, error) {
-	subroutineLogger := logger.NewFromZerolog(log.With().Str("subroutine", subroutine.GetName()).Logger())
+	subroutineLogger := log.ChildLogger("subroutine", subroutine.GetName())
 	ctx = logger.SetLoggerInContext(ctx, subroutineLogger)
 	subroutineLogger.Debug().Msg("start subroutine")
 

--- a/controller/lifecycle/lifecycle_test.go
+++ b/controller/lifecycle/lifecycle_test.go
@@ -15,7 +15,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/openmfp/golang-commons/controller/testSupport"
-	"github.com/openmfp/golang-commons/logger"
 	"github.com/openmfp/golang-commons/logger/testlogger"
 	"github.com/openmfp/golang-commons/sentry"
 )
@@ -483,8 +482,6 @@ func (r *testReconciler) Reconcile(ctx context.Context, req controllerruntime.Re
 
 func createLifecycleManager(subroutines []Subroutine, c client.Client) (*LifecycleManager, *testlogger.TestLogger) {
 	log := testlogger.New()
-	ctx := logger.SetLoggerInContext(context.Background(), log.Logger)
-
-	mgr := NewLifecycleManager(ctx, "test-operator", "test-controller", c, subroutines)
+	mgr := NewLifecycleManager(log.Logger, "test-operator", "test-controller", c, subroutines)
 	return mgr, log
 }

--- a/controller/lifecycle/lifecycle_test.go
+++ b/controller/lifecycle/lifecycle_test.go
@@ -6,9 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openmfp/golang-commons/controller/testSupport"
-	"github.com/openmfp/golang-commons/logger/testlogger"
-	"github.com/openmfp/golang-commons/sentry"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -16,6 +13,11 @@ import (
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/openmfp/golang-commons/controller/testSupport"
+	"github.com/openmfp/golang-commons/logger"
+	"github.com/openmfp/golang-commons/logger/testlogger"
+	"github.com/openmfp/golang-commons/sentry"
 )
 
 func TestLifecycle(t *testing.T) {
@@ -480,8 +482,9 @@ func (r *testReconciler) Reconcile(ctx context.Context, req controllerruntime.Re
 }
 
 func createLifecycleManager(subroutines []Subroutine, c client.Client) (*LifecycleManager, *testlogger.TestLogger) {
-	logger := testlogger.New()
+	log := testlogger.New()
+	ctx := logger.SetLoggerInContext(context.Background(), log.Logger)
 
-	mgr := NewLifecycleManager(logger.Logger, "test-operator", "test-controller", c, subroutines)
-	return mgr, logger
+	mgr := NewLifecycleManager(ctx, "test-operator", "test-controller", c, subroutines)
+	return mgr, log
 }

--- a/controller/lifecycle/spread.go
+++ b/controller/lifecycle/spread.go
@@ -32,22 +32,22 @@ func getNextReconcileTime() time.Duration {
 }
 
 // onNextReconcile is a helper function to set the next reconcile time and return the requeueAfter time
-func onNextReconcile(instanceStatusObj RuntimeObjectSpreadReconcileStatus, logger *logger.Logger) (ctrl.Result, error) {
+func onNextReconcile(instanceStatusObj RuntimeObjectSpreadReconcileStatus, log *logger.Logger) (ctrl.Result, error) {
 	requeueAfter := time.Until(instanceStatusObj.GetNextReconcileTime().Time.UTC())
-	logger.Debug().Int64("minutes-till-next-execution", int64(requeueAfter.Minutes())).Msg("Completed reconciliation, no processing needed")
+	log.Debug().Int64("minutes-till-next-execution", int64(requeueAfter.Minutes())).Msg("Completed reconciliation, no processing needed")
 	return ctrl.Result{RequeueAfter: requeueAfter}, nil
 }
 
 // setNextReconcileTime calculates and sets the next reconcile time for the instance
-func setNextReconcileTime(instanceStatusObj RuntimeObjectSpreadReconcileStatus, logger *logger.Logger) {
+func setNextReconcileTime(instanceStatusObj RuntimeObjectSpreadReconcileStatus, log *logger.Logger) {
 	nextReconcileTime := getNextReconcileTime()
-	logger.Debug().Int64("minutes-till-next-execution", int64(nextReconcileTime.Minutes())).Msg("Setting next reconcile time for the instance")
+	log.Debug().Int64("minutes-till-next-execution", int64(nextReconcileTime.Minutes())).Msg("Setting next reconcile time for the instance")
 	instanceStatusObj.SetNextReconcileTime(v1.NewTime(time.Now().Add(nextReconcileTime)))
 }
 
 // updateObservedGeneration updates the observed generation of the instance struct
-func updateObservedGeneration(instanceStatusObj RuntimeObjectSpreadReconcileStatus, logger *logger.Logger) {
-	logger.Debug().Int64("observed-generation", instanceStatusObj.GetObservedGeneration()).Int64("generation", instanceStatusObj.GetGeneration()).Msg("Updating observed generation")
+func updateObservedGeneration(instanceStatusObj RuntimeObjectSpreadReconcileStatus, log *logger.Logger) {
+	log.Debug().Int64("observed-generation", instanceStatusObj.GetObservedGeneration()).Int64("generation", instanceStatusObj.GetGeneration()).Msg("Updating observed generation")
 	instanceStatusObj.SetObservedGeneration(instanceStatusObj.GetGeneration())
 }
 func removeRefreshLabelIfExists(instance RuntimeObject) bool {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -114,8 +114,8 @@ func NewRequestLoggerFromZerolog(ctx context.Context, logger zerolog.Logger) *Lo
 	return &Logger{logger}
 }
 
-func SetLoggerInContext(ctx context.Context, logger *Logger) context.Context {
-	return context.WithValue(ctx, keys.LoggerCtxKey, logger)
+func SetLoggerInContext(ctx context.Context, log *Logger) context.Context {
+	return context.WithValue(ctx, keys.LoggerCtxKey, log)
 }
 
 // LoadFromContext returns the Logger from a given context


### PR DESCRIPTION
This PR contains the following main improvements:

- This change adds by default the operatorName and controllerName attributes to the log attributes.
- Also where we pass a logger this PR cleans occurrences of the `logger *logger.Logger` to avoid variable and import conflicts
- It provides additional convenience functions to creating child loggers
