### PR TITLE
fix/make-signature-algorithms-configurable

### DIFF
--- a/context/service_context.go
+++ b/context/service_context.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-jose/go-jose/v4"
+
 	"github.com/openmfp/golang-commons/context/keys"
 	"github.com/openmfp/golang-commons/jwt"
 	"github.com/openmfp/golang-commons/logger"
@@ -55,8 +57,8 @@ func GetAuthHeaderFromContext(ctx context.Context) (string, error) {
 	return auth, nil
 }
 
-func AddWebTokenToContext(ctx context.Context, idToken string) context.Context {
-	token, err := jwt.New(idToken)
+func AddWebTokenToContext(ctx context.Context, idToken string, signatureAlgorithms []jose.SignatureAlgorithm) context.Context {
+	token, err := jwt.New(idToken, signatureAlgorithms)
 	if err != nil {
 		logger.StdLogger.Error().Err(err).Msg("cannot add given id_token to context")
 		return ctx

--- a/context/service_context_test.go
+++ b/context/service_context_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/go-jose/go-jose/v4"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 
@@ -13,6 +14,8 @@ import (
 )
 
 type astruct struct{}
+
+var signatureAlgorithms = []jose.SignatureAlgorithm{jose.HS256}
 
 func TestAddSpiffeToContext(t *testing.T) {
 	t.Parallel()
@@ -113,7 +116,7 @@ func TestAddWebTokenToContext(t *testing.T) {
 	tokenString, err := generateJWT(issuer)
 	assert.NoError(t, err)
 
-	ctx = openmfpctx.AddWebTokenToContext(ctx, tokenString)
+	ctx = openmfpctx.AddWebTokenToContext(ctx, tokenString, signatureAlgorithms)
 
 	token, err := openmfpctx.GetWebTokenFromContext(ctx)
 	assert.Nil(t, err)
@@ -136,7 +139,7 @@ func TestAddWebTokenToContextWrongToken(t *testing.T) {
 	initialContext := context.Background()
 	tokenString := "not-a-token"
 
-	ctx := openmfpctx.AddWebTokenToContext(initialContext, tokenString)
+	ctx := openmfpctx.AddWebTokenToContext(initialContext, tokenString, signatureAlgorithms)
 
 	assert.Equal(t, initialContext, ctx)
 }

--- a/jwt/model.go
+++ b/jwt/model.go
@@ -33,8 +33,7 @@ type WebToken struct {
 
 // New retrieves a new WebToken from an id_token string provided by OpenID communication
 // When not able to parse or deserialize the requested claims, it will return an error
-func New(idToken string) (webToken WebToken, err error) {
-	signatureAlgorithms := []jose.SignatureAlgorithm{jose.HS256}
+func New(idToken string, signatureAlgorithms []jose.SignatureAlgorithm) (webToken WebToken, err error) {
 	token, parseErr := jwt.ParseSigned(idToken, signatureAlgorithms)
 	if parseErr != nil {
 		err = fmt.Errorf("unable to parse id_token: [%s], %w", idToken, err)

--- a/jwt/model_test.go
+++ b/jwt/model_test.go
@@ -3,9 +3,12 @@ package jwt
 import (
 	"testing"
 
+	"github.com/go-jose/go-jose/v4"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 )
+
+var signatureAlgorithms = []jose.SignatureAlgorithm{jose.HS256}
 
 func TestNew(t *testing.T) {
 	issuer := "my-issuer"
@@ -15,7 +18,7 @@ func TestNew(t *testing.T) {
 	tokenString, err := token.SignedString([]byte("a_secret_key"))
 	assert.NoError(t, err)
 
-	webToken, err := New(tokenString)
+	webToken, err := New(tokenString, signatureAlgorithms)
 	assert.NoError(t, err)
 	assert.NotNil(t, webToken)
 	assert.Equal(t, issuer, webToken.Issuer)
@@ -23,7 +26,7 @@ func TestNew(t *testing.T) {
 
 func TestNewAndFail(t *testing.T) {
 	tokenString := "just a string"
-	_, err := New(tokenString)
+	_, err := New(tokenString, signatureAlgorithms)
 	assert.Error(t, err)
 
 }


### PR DESCRIPTION
Different signatureAlgorithms may be used, this change allows the consumer to provide the one needed.