### PR TITLE
feat(fga): adding a SanitizeUserID helper to enable more types of user identifiers in OpenFGA

### DIFF
--- a/fga/helpers/helper.go
+++ b/fga/helpers/helper.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/golang-lru/v2/expirable"
@@ -73,4 +74,9 @@ func IsDuplicateWriteError(err error) bool {
 
 	s, ok := status.FromError(err)
 	return ok && int32(s.Code()) == int32(openfgav1.ErrorCode_write_failed_due_to_invalid_input)
+}
+
+// Sanitizes the userID by replacing all colons with underscores to also enable the use of kubernetes service accounts
+func SanitizeUserID(userID string) string {
+	return strings.ReplaceAll(userID, ":", "_")
 }

--- a/fga/helpers/helper_test.go
+++ b/fga/helpers/helper_test.go
@@ -169,3 +169,23 @@ func TestIsDuplicateWriteError(t *testing.T) {
 		})
 	}
 }
+
+func TestSanitizeUserID(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		out  string
+	}{
+		{
+			name: "should remove all colons",
+			in:   "system:serviceaccount:default:default",
+			out:  "system_serviceaccount_default_default",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			out := SanitizeUserID(test.in)
+			assert.Equal(t, test.out, out)
+		})
+	}
+}


### PR DESCRIPTION
In order to support multiple cases where users of the system need to be able to defer authorization decisions also for kubernetes service accounts, this PR adds a helper that ensures an user identifier can be part of OpenFGA even with `:` as it replaces it with `_` to be compliant with the OpenFGA spec.