### PR TITLE
Feature: also log to stdout if a test logger is used

### DIFF
--- a/logger/testlogger/test_logger_test.go
+++ b/logger/testlogger/test_logger_test.go
@@ -25,7 +25,8 @@ func TestTestLogger(t *testing.T) {
 
 		t.Run("two entries", func(t *testing.T) {
 			// Arrange
-			testLogger := New()
+			// Hide Log output is hard to test, since the real stdout is hard to catch
+			testLogger := New().HideLogOutput()
 
 			// Act
 			testLogger.Logger.Info().Msg("foo")


### PR DESCRIPTION
Not seeing the actual log slows down test development. So by default the log is also written to stdout.