### PR TITLE
Feat: lifecycle.WithPrepareContextFunc to share data

### DIFF
--- a/controller/lifecycle/lifecycle.go
+++ b/controller/lifecycle/lifecycle.go
@@ -27,13 +27,14 @@ import (
 )
 
 type LifecycleManager struct {
-	log              *logger.Logger
-	client           client.Client
-	subroutines      []Subroutine
-	operatorName     string
-	controllerName   string
-	spreadReconciles bool
-	manageConditions bool
+	log                *logger.Logger
+	client             client.Client
+	subroutines        []Subroutine
+	operatorName       string
+	controllerName     string
+	spreadReconciles   bool
+	manageConditions   bool
+	prepareContextFunc func(ctx context.Context, instance RuntimeObject) (context.Context, errors.OperatorError)
 }
 
 type RuntimeObject interface {
@@ -109,6 +110,14 @@ func (l *LifecycleManager) Reconcile(ctx context.Context, req ctrl.Request, inst
 
 	if l.manageConditions {
 		setInstanceConditionUnknownIfNotSet(&conditions)
+	}
+
+	if l.prepareContextFunc != nil {
+		localCtx, oErr := l.prepareContextFunc(ctx, instance)
+		if oErr != nil {
+			return l.handleOperatorError(ctx, oErr, "failed to prepare context")
+		}
+		ctx = localCtx
 	}
 
 	// In case of deletion execute the finalize subroutines in the reverse order as subroutine processing
@@ -260,6 +269,19 @@ func updateStatus(ctx context.Context, cl client.Client, original runtime.Object
 	return nil
 }
 
+func (l *LifecycleManager) handleOperatorError(ctx context.Context, operatorError errors.OperatorError, msg string) (ctrl.Result, error) {
+	l.log.Error().Bool("retry", operatorError.Retry()).Bool("sentry", operatorError.Sentry()).Err(operatorError.Err()).Msg(msg)
+	if operatorError.Sentry() {
+		sentry.CaptureError(operatorError.Err(), sentry.GetSentryTagsFromContext(ctx))
+	}
+
+	if operatorError.Retry() {
+		return ctrl.Result{}, operatorError.Err()
+	}
+
+	return ctrl.Result{}, nil
+}
+
 func (l *LifecycleManager) handleClientError(msg string, log *logger.Logger, err error, sentryTags sentry.Tags) (ctrl.Result, error) {
 	log.Error().Err(err).Msg(msg)
 	sentry.CaptureError(err, sentryTags)
@@ -370,4 +392,12 @@ func (l *LifecycleManager) SetupWithManager(mgr ctrl.Manager, maxReconciles int,
 		WithOptions(controller.Options{MaxConcurrentReconciles: maxReconciles}).
 		WithEventFilter(predicate.And(eventPredicates...)).
 		Complete(r)
+}
+
+// WithPrepareContextFunc allows to set a function that prepares the context before each reconciliation
+// This can be used to add additional information to the context that is needed by the subroutines
+// You need to return a new context and an OperatorError in case of an error
+func (l *LifecycleManager) WithPrepareContextFunc(prepareFunction func(ctx context.Context, instance RuntimeObject) (context.Context, errors.OperatorError)) *LifecycleManager {
+	l.prepareContextFunc = prepareFunction
+	return l
 }

--- a/controller/lifecycle/lifecycle.go
+++ b/controller/lifecycle/lifecycle.go
@@ -34,7 +34,7 @@ type LifecycleManager struct {
 	controllerName     string
 	spreadReconciles   bool
 	manageConditions   bool
-	prepareContextFunc func(ctx context.Context, instance RuntimeObject) (context.Context, errors.OperatorError)
+	prepareContextFunc PrepareContextFunc
 }
 
 type RuntimeObject interface {
@@ -394,10 +394,12 @@ func (l *LifecycleManager) SetupWithManager(mgr ctrl.Manager, maxReconciles int,
 		Complete(r)
 }
 
+type PrepareContextFunc func(ctx context.Context, instance RuntimeObject) (context.Context, errors.OperatorError)
+
 // WithPrepareContextFunc allows to set a function that prepares the context before each reconciliation
 // This can be used to add additional information to the context that is needed by the subroutines
 // You need to return a new context and an OperatorError in case of an error
-func (l *LifecycleManager) WithPrepareContextFunc(prepareFunction func(ctx context.Context, instance RuntimeObject) (context.Context, errors.OperatorError)) *LifecycleManager {
+func (l *LifecycleManager) WithPrepareContextFunc(prepareFunction PrepareContextFunc) *LifecycleManager {
 	l.prepareContextFunc = prepareFunction
 	return l
 }

--- a/controller/lifecycle/lifecycle_test.go
+++ b/controller/lifecycle/lifecycle_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	goerrors "errors"
 	operrors "github.com/openmfp/golang-commons/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -1020,7 +1021,7 @@ func TestLifecycle(t *testing.T) {
 			ctx = sentry.ContextWithSentryTags(ctx, map[string]string{})
 
 			// Act
-			result, err := lm.handleOperatorError(ctx, operrors.NewOperatorError(fmt.Errorf(errorMessage), true, true), "handle op error")
+			result, err := lm.handleOperatorError(ctx, operrors.NewOperatorError(goerrors.New(errorMessage), true, true), "handle op error")
 
 			// Assert
 			assert.Error(t, err)
@@ -1040,7 +1041,7 @@ func TestLifecycle(t *testing.T) {
 			lm, log := createLifecycleManager([]Subroutine{}, fakeClient)
 
 			// Act
-			result, err := lm.handleOperatorError(ctx, operrors.NewOperatorError(fmt.Errorf(errorMessage), false, false), "handle op error")
+			result, err := lm.handleOperatorError(ctx, operrors.NewOperatorError(goerrors.New(errorMessage), false, false), "handle op error")
 
 			// Assert
 			assert.Nil(t, err)
@@ -1072,6 +1073,7 @@ func TestLifecycle(t *testing.T) {
 			assert.NoError(t, err)
 
 			err = fakeClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, testApiObject)
+			assert.NoError(t, err)
 			assert.Equal(t, "valueFromContext", testApiObject.Status.Some)
 		})
 
@@ -1083,7 +1085,7 @@ func TestLifecycle(t *testing.T) {
 
 			lm, _ := createLifecycleManager([]Subroutine{contextValueSubroutine{}}, fakeClient)
 			lm = lm.WithPrepareContextFunc(func(ctx context.Context, instance RuntimeObject) (context.Context, operrors.OperatorError) {
-				return nil, operrors.NewOperatorError(fmt.Errorf(errorMessage), true, false)
+				return nil, operrors.NewOperatorError(goerrors.New(errorMessage), true, false)
 			})
 			tr := &testReconciler{lifecycleManager: lm}
 			result, err := tr.Reconcile(ctx, controllerruntime.Request{NamespacedName: types.NamespacedName{Name: name, Namespace: namespace}})

--- a/controller/lifecycle/lifecycle_test.go
+++ b/controller/lifecycle/lifecycle_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	operrors "github.com/openmfp/golang-commons/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	v1 "k8s.io/api/core/v1"
@@ -31,6 +32,12 @@ func TestLifecycle(t *testing.T) {
 		NamespacedName: types.NamespacedName{
 			Namespace: namespace,
 			Name:      name,
+		},
+	}
+	testApiObject := &testSupport.TestApiObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
 		},
 	}
 	ctx := context.Background()
@@ -1000,6 +1007,92 @@ func TestLifecycle(t *testing.T) {
 
 		// Assert
 		assert.Error(t, err)
+	})
+
+	errorMessage := "oh nose"
+	t.Run("handleOperatorError", func(t *testing.T) {
+		t.Run("Should handle an operator error with retry and sentry", func(t *testing.T) {
+			// Arrange
+			instance := &implementConditions{}
+			fakeClient := testSupport.CreateFakeClient(t, instance)
+
+			lm, log := createLifecycleManager([]Subroutine{}, fakeClient)
+			ctx = sentry.ContextWithSentryTags(ctx, map[string]string{})
+
+			// Act
+			result, err := lm.handleOperatorError(ctx, operrors.NewOperatorError(fmt.Errorf(errorMessage), true, true), "handle op error")
+
+			// Assert
+			assert.Error(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, errorMessage, err.Error())
+
+			errorMessages, err := log.GetErrorMessages()
+			assert.NoError(t, err)
+			assert.Equal(t, errorMessage, *errorMessages[0].Error)
+		})
+
+		t.Run("Should handle an operator error without retry", func(t *testing.T) {
+			// Arrange
+			instance := &implementConditions{}
+			fakeClient := testSupport.CreateFakeClient(t, instance)
+
+			lm, log := createLifecycleManager([]Subroutine{}, fakeClient)
+
+			// Act
+			result, err := lm.handleOperatorError(ctx, operrors.NewOperatorError(fmt.Errorf(errorMessage), false, false), "handle op error")
+
+			// Assert
+			assert.Nil(t, err)
+			assert.NotNil(t, result)
+
+			errorMessages, err := log.GetErrorMessages()
+			assert.NoError(t, err)
+			assert.Equal(t, errorMessage, *errorMessages[0].Error)
+		})
+	})
+
+	t.Run("Prepare Context", func(t *testing.T) {
+		t.Run("Sets a context that can be used in the subroutine", func(t *testing.T) {
+			// Arrange
+			ctx := context.Background()
+
+			fakeClient := testSupport.CreateFakeClient(t, testApiObject)
+
+			lm, _ := createLifecycleManager([]Subroutine{contextValueSubroutine{}}, fakeClient)
+			lm = lm.WithPrepareContextFunc(func(ctx context.Context, instance RuntimeObject) (context.Context, operrors.OperatorError) {
+				return context.WithValue(ctx, contextValueKey, "valueFromContext"), nil
+			})
+			tr := &testReconciler{lifecycleManager: lm}
+			result, err := tr.Reconcile(ctx, controllerruntime.Request{NamespacedName: types.NamespacedName{Name: name, Namespace: namespace}})
+
+			// Then
+			assert.NotNil(t, ctx)
+			assert.NotNil(t, result)
+			assert.NoError(t, err)
+
+			err = fakeClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, testApiObject)
+			assert.Equal(t, "valueFromContext", testApiObject.Status.Some)
+		})
+
+		t.Run("Handles the errors correctly", func(t *testing.T) {
+			// Arrange
+			ctx := context.Background()
+
+			fakeClient := testSupport.CreateFakeClient(t, testApiObject)
+
+			lm, _ := createLifecycleManager([]Subroutine{contextValueSubroutine{}}, fakeClient)
+			lm = lm.WithPrepareContextFunc(func(ctx context.Context, instance RuntimeObject) (context.Context, operrors.OperatorError) {
+				return nil, operrors.NewOperatorError(fmt.Errorf(errorMessage), true, false)
+			})
+			tr := &testReconciler{lifecycleManager: lm}
+			result, err := tr.Reconcile(ctx, controllerruntime.Request{NamespacedName: types.NamespacedName{Name: name, Namespace: namespace}})
+
+			// Then
+			assert.NotNil(t, ctx)
+			assert.NotNil(t, result)
+			assert.Error(t, err)
+		})
 	})
 }
 

--- a/controller/lifecycle/testSupport_test.go
+++ b/controller/lifecycle/testSupport_test.go
@@ -3,6 +3,7 @@ package lifecycle
 import (
 	"context"
 	"fmt"
+	"github.com/openmfp/golang-commons/context/keys"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -177,7 +178,7 @@ func (m *implementConditionsAndSpreadReconciles) SetNextReconcileTime(time metav
 type contextValueSubroutine struct {
 }
 
-const contextValueKey = "contextValueKey"
+const contextValueKey = keys.ContextKey("contextValueKey")
 
 func (f contextValueSubroutine) Process(ctx context.Context, r RuntimeObject) (controllerruntime.Result, errors.OperatorError) {
 	if instance, ok := r.(*testSupport.TestApiObject); ok {

--- a/controller/lifecycle/testSupport_test.go
+++ b/controller/lifecycle/testSupport_test.go
@@ -173,3 +173,27 @@ func (m *implementConditionsAndSpreadReconciles) GetNextReconcileTime() metav1.T
 func (m *implementConditionsAndSpreadReconciles) SetNextReconcileTime(time metav1.Time) {
 	m.Status.NextReconcileTime = time
 }
+
+type contextValueSubroutine struct {
+}
+
+const contextValueKey = "contextValueKey"
+
+func (f contextValueSubroutine) Process(ctx context.Context, r RuntimeObject) (controllerruntime.Result, errors.OperatorError) {
+	if instance, ok := r.(*testSupport.TestApiObject); ok {
+		instance.Status.Some = ctx.Value(contextValueKey).(string)
+	}
+	return controllerruntime.Result{}, nil
+}
+
+func (f contextValueSubroutine) Finalize(_ context.Context, _ RuntimeObject) (controllerruntime.Result, errors.OperatorError) {
+	return controllerruntime.Result{}, nil
+}
+
+func (f contextValueSubroutine) Finalizers() []string {
+	return []string{}
+}
+
+func (c contextValueSubroutine) GetName() string {
+	return "contextValueSubroutine"
+}


### PR DESCRIPTION
WithPrepareContextFunc allows to set a function that prepares the context before each reconciliation This can be used to add additional information to the context that is needed by the subroutines You need to return a new context and an OperatorError in case of an error