### PR TITLE
Extend LifecycleManager to watch resources

### DIFF
--- a/controller/lifecycle/lifecycle_test.go
+++ b/controller/lifecycle/lifecycle_test.go
@@ -492,7 +492,7 @@ func TestLifecycle(t *testing.T) {
 		}
 
 		// Act
-		err = lm.SetupWithManager(m, 0, "testReconciler", instance, "test", tr, log, nil)
+		err = lm.SetupWithManager(m, 0, "testReconciler", instance, "test", tr, log)
 
 		// Assert
 		assert.NoError(t, err)
@@ -516,7 +516,7 @@ func TestLifecycle(t *testing.T) {
 		}
 
 		// Act
-		err = lm.SetupWithManager(m, 0, "testReconciler", instance, "test", tr, log, nil)
+		err = lm.SetupWithManager(m, 0, "testReconciler", instance, "test", tr, log)
 
 		// Assert
 		assert.Error(t, err)
@@ -948,7 +948,7 @@ func TestLifecycle(t *testing.T) {
 		tr := &testReconciler{lifecycleManager: lm}
 
 		// Act
-		err = lm.SetupWithManager(m, 0, "testReconciler", instance, "test", tr, log.Logger, nil)
+		err = lm.SetupWithManager(m, 0, "testReconciler", instance, "test", tr, log.Logger)
 
 		// Assert
 		assert.NoError(t, err)
@@ -967,7 +967,7 @@ func TestLifecycle(t *testing.T) {
 		tr := &testReconciler{lifecycleManager: lm}
 
 		// Act
-		err = lm.SetupWithManager(m, 0, "testReconciler", instance, "test", tr, log.Logger, nil)
+		err = lm.SetupWithManager(m, 0, "testReconciler", instance, "test", tr, log.Logger)
 
 		// Assert
 		assert.Error(t, err)
@@ -986,7 +986,7 @@ func TestLifecycle(t *testing.T) {
 		tr := &testReconciler{lifecycleManager: lm}
 
 		// Act
-		err = lm.SetupWithManager(m, 0, "testReconciler", instance, "test", tr, log.Logger, nil)
+		err = lm.SetupWithManager(m, 0, "testReconciler", instance, "test", tr, log.Logger)
 
 		// Assert
 		assert.NoError(t, err)
@@ -1005,7 +1005,7 @@ func TestLifecycle(t *testing.T) {
 		tr := &testReconciler{lifecycleManager: lm}
 
 		// Act
-		err = lm.SetupWithManager(m, 0, "testReconciler", instance, "test", tr, log.Logger, nil)
+		err = lm.SetupWithManager(m, 0, "testReconciler", instance, "test", tr, log.Logger)
 
 		// Assert
 		assert.Error(t, err)

--- a/controller/lifecycle/lifecycle_test.go
+++ b/controller/lifecycle/lifecycle_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	goerrors "errors"
+
 	operrors "github.com/openmfp/golang-commons/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -491,7 +492,7 @@ func TestLifecycle(t *testing.T) {
 		}
 
 		// Act
-		err = lm.SetupWithManager(m, 0, "testReconciler", instance, "test", tr, log)
+		err = lm.SetupWithManager(m, 0, "testReconciler", instance, "test", tr, log, nil)
 
 		// Assert
 		assert.NoError(t, err)
@@ -515,7 +516,7 @@ func TestLifecycle(t *testing.T) {
 		}
 
 		// Act
-		err = lm.SetupWithManager(m, 0, "testReconciler", instance, "test", tr, log)
+		err = lm.SetupWithManager(m, 0, "testReconciler", instance, "test", tr, log, nil)
 
 		// Assert
 		assert.Error(t, err)
@@ -947,7 +948,7 @@ func TestLifecycle(t *testing.T) {
 		tr := &testReconciler{lifecycleManager: lm}
 
 		// Act
-		err = lm.SetupWithManager(m, 0, "testReconciler", instance, "test", tr, log.Logger)
+		err = lm.SetupWithManager(m, 0, "testReconciler", instance, "test", tr, log.Logger, nil)
 
 		// Assert
 		assert.NoError(t, err)
@@ -966,7 +967,7 @@ func TestLifecycle(t *testing.T) {
 		tr := &testReconciler{lifecycleManager: lm}
 
 		// Act
-		err = lm.SetupWithManager(m, 0, "testReconciler", instance, "test", tr, log.Logger)
+		err = lm.SetupWithManager(m, 0, "testReconciler", instance, "test", tr, log.Logger, nil)
 
 		// Assert
 		assert.Error(t, err)
@@ -985,7 +986,7 @@ func TestLifecycle(t *testing.T) {
 		tr := &testReconciler{lifecycleManager: lm}
 
 		// Act
-		err = lm.SetupWithManager(m, 0, "testReconciler", instance, "test", tr, log.Logger)
+		err = lm.SetupWithManager(m, 0, "testReconciler", instance, "test", tr, log.Logger, nil)
 
 		// Assert
 		assert.NoError(t, err)
@@ -1004,7 +1005,7 @@ func TestLifecycle(t *testing.T) {
 		tr := &testReconciler{lifecycleManager: lm}
 
 		// Act
-		err = lm.SetupWithManager(m, 0, "testReconciler", instance, "test", tr, log.Logger)
+		err = lm.SetupWithManager(m, 0, "testReconciler", instance, "test", tr, log.Logger, nil)
 
 		// Assert
 		assert.Error(t, err)


### PR DESCRIPTION
### Introduced Changes:

- Add a new separate `LifecycleManager.SetupWithManagerBuilder` method that returns the `controller-builder` to allow a more flexible watch API, which enables watching other resources different from the resources watched with the `For(...)` method, like using `Owns(...)` or `Watches(...)`.

Needed for: https://github.com/openmfp/modular-models-operator/pull/3