### PR TITLE
chore: Improve logging in case of spread reconciles

### DIFF
--- a/controller/lifecycle/lifecycle.go
+++ b/controller/lifecycle/lifecycle.go
@@ -97,6 +97,7 @@ func (l *LifecycleManager) Reconcile(ctx context.Context, req ctrl.Request, inst
 
 		reconcileRequired := generationIsDifferent || isAfterNextReconcileTime || refreshRequested
 		if !reconcileRequired {
+			log.Info().Msg("skipping reconciliation, spread reconcile is active. No processing needed")
 			return onNextReconcile(instanceStatusObj, log)
 		}
 	}


### PR DESCRIPTION
lifecycle is supposed to log the start and the end of a reconcile. The end of the reconcile in case of spread is now also logged