### PR TITLE
fix: dont add finalizers during deletion runs

### DIFF
--- a/controller/lifecycle/lifecycle.go
+++ b/controller/lifecycle/lifecycle.go
@@ -352,6 +352,10 @@ func (l *LifecycleManager) reconcileSubroutine(ctx context.Context, instance Run
 }
 
 func (l *LifecycleManager) addFinalizersIfNeeded(ctx context.Context, instance RuntimeObject) error {
+	if !instance.GetDeletionTimestamp().IsZero() {
+		return nil
+	}
+
 	update := false
 	for _, subroutine := range l.subroutines {
 		if len(subroutine.Finalizers()) > 0 {


### PR DESCRIPTION
Currently there is an error when using multiple finalizers. The lifecycle logic tries to add finalizers during a deletion run. This is forbidden:

```
metadata.finalizers: Forbidden: no new finalizers can be added if the object is being deleted, found new finalizers
```