### PR TITLE
fix(jwt): improve error handling in New function for id_token parsing

### DIFF
--- a/jwt/model.go
+++ b/jwt/model.go
@@ -36,7 +36,7 @@ type WebToken struct {
 func New(idToken string, signatureAlgorithms []jose.SignatureAlgorithm) (webToken WebToken, err error) {
 	token, parseErr := jwt.ParseSigned(idToken, signatureAlgorithms)
 	if parseErr != nil {
-		err = fmt.Errorf("unable to parse id_token: [%s], %w", idToken, err)
+		err = fmt.Errorf("unable to parse id_token: [%s], %w", idToken, parseErr)
 		return
 	}
 


### PR DESCRIPTION
During error investigations I noticed that the function errored out due to a parsing error but the log did not contain the relevant error information. The wrong variable was used in the log