### PR TITLE
feat(controller): add read-only mode to LifecycleManager

### DIFF
--- a/controller/lifecycle/lifecycle.go
+++ b/controller/lifecycle/lifecycle.go
@@ -423,6 +423,10 @@ func (l *LifecycleManager) SetupWithManagerBuilder(mgr ctrl.Manager, maxReconcil
 		return nil, err
 	}
 
+	if (l.manageConditions || l.spreadReconciles) && l.readOnly {
+		return nil, fmt.Errorf("cannot use conditions or spread reconciles in read-only mode")
+	}
+
 	eventPredicates = append([]predicate.Predicate{filter.DebugResourcesBehaviourPredicate(debugLabelValue)}, eventPredicates...)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(reconcilerName).

--- a/controller/lifecycle/lifecycle.go
+++ b/controller/lifecycle/lifecycle.go
@@ -35,6 +35,7 @@ type LifecycleManager struct {
 	controllerName     string
 	spreadReconciles   bool
 	manageConditions   bool
+	readOnly           bool
 	prepareContextFunc PrepareContextFunc
 }
 
@@ -154,7 +155,9 @@ func (l *LifecycleManager) Reconcile(ctx context.Context, req ctrl.Request, inst
 			if !retry {
 				l.markResourceAsFinal(instance, log, conditions, v1.ConditionFalse)
 			}
-			_ = updateStatus(ctx, l.client, originalCopy, instance, log, generationChanged, sentryTags)
+			if !l.readOnly {
+				_ = updateStatus(ctx, l.client, originalCopy, instance, log, generationChanged, sentryTags)
+			}
 			if !retry {
 				return ctrl.Result{}, nil
 			}
@@ -188,9 +191,11 @@ func (l *LifecycleManager) Reconcile(ctx context.Context, req ctrl.Request, inst
 		MustToRuntimeObjectConditionsInterface(instance, log).SetConditions(conditions)
 	}
 
-	err = updateStatus(ctx, l.client, originalCopy, instance, log, generationChanged, sentryTags)
-	if err != nil {
-		return result, err
+	if !l.readOnly {
+		err = updateStatus(ctx, l.client, originalCopy, instance, log, generationChanged, sentryTags)
+		if err != nil {
+			return result, err
+		}
 	}
 
 	if l.spreadReconciles && instance.GetDeletionTimestamp().IsZero() {
@@ -352,6 +357,10 @@ func (l *LifecycleManager) reconcileSubroutine(ctx context.Context, instance Run
 }
 
 func (l *LifecycleManager) addFinalizersIfNeeded(ctx context.Context, instance RuntimeObject) error {
+	if l.readOnly {
+		return nil
+	}
+
 	if !instance.GetDeletionTimestamp().IsZero() {
 		return nil
 	}
@@ -386,6 +395,10 @@ func (l *LifecycleManager) addFinalizerIfNeeded(instance RuntimeObject, subrouti
 }
 
 func (l *LifecycleManager) removeFinalizerIfNeeded(ctx context.Context, instance RuntimeObject, subroutine Subroutine, result ctrl.Result) errors.OperatorError {
+	if l.readOnly {
+		return nil
+	}
+
 	if !result.Requeue && result.RequeueAfter == 0 {
 		update := false
 		for _, f := range subroutine.Finalizers() {
@@ -434,5 +447,12 @@ type PrepareContextFunc func(ctx context.Context, instance RuntimeObject) (conte
 // You need to return a new context and an OperatorError in case of an error
 func (l *LifecycleManager) WithPrepareContextFunc(prepareFunction PrepareContextFunc) *LifecycleManager {
 	l.prepareContextFunc = prepareFunction
+	return l
+}
+
+// WithReadOnly allows to set the controller to read-only mode
+// In read-only mode, the controller will not update the status of the instance
+func (l *LifecycleManager) WithReadOnly() *LifecycleManager {
+	l.readOnly = true
 	return l
 }


### PR DESCRIPTION
This PR adds a readonly mode to the lifecycle controller that skips all eventual status update to work with initializing workspaces in kcp.