### PR TITLE
User ID to context functions

### DIFF
--- a/context/keys/keys.go
+++ b/context/keys/keys.go
@@ -15,4 +15,5 @@ const (
 	TenantIdCtxKey       = ContextKey(jwt.TenantIdCtxKey)
 	AuthHeaderCtxKey     = ContextKey(jwt.AuthHeaderCtxKey)
 	WebTokenCtxKey       = ContextKey(jwt.WebTokenCtxKey)
+	UserIDCtxKey         = ContextKey("userId")
 )

--- a/context/service_context.go
+++ b/context/service_context.go
@@ -87,3 +87,21 @@ func GetIsTechnicalIssuerFromContext(ctx context.Context) bool {
 
 	return isTechnicalIsser
 }
+
+func AddUserIDToContext(ctx context.Context, userID string) context.Context {
+	return context.WithValue(ctx, keys.UserIDCtxKey, userID)
+}
+
+func GetUserIDFromContext(ctx context.Context) (string, error) {
+	userID, ok := ctx.Value(keys.UserIDCtxKey).(string)
+	if !ok {
+		return userID, fmt.Errorf("someone stored a wrong value in the [%s] key with type [%T], expected [string]", keys.UserIDCtxKey, ctx.Value(keys.UserIDCtxKey))
+	}
+	return userID, nil
+}
+
+func HasUserIDInContext(ctx context.Context) bool {
+	_, ok := ctx.Value(keys.UserIDCtxKey).(string)
+	return ok
+}
+


### PR DESCRIPTION
Helper functions for adding UserID to the service context. It's required so that when checking in the user GraphQL directive, we also save his ID in the context in order to reuse it in the business logic of the application