### PR TITLE
feat: use patch for finalizer updates

### DIFF
--- a/controller/lifecycle/lifecycle.go
+++ b/controller/lifecycle/lifecycle.go
@@ -366,6 +366,7 @@ func (l *LifecycleManager) addFinalizersIfNeeded(ctx context.Context, instance R
 	}
 
 	update := false
+	original := instance.DeepCopyObject().(client.Object)
 	for _, subroutine := range l.subroutines {
 		if len(subroutine.Finalizers()) > 0 {
 			needsUpdate := l.addFinalizerIfNeeded(instance, subroutine)
@@ -375,7 +376,8 @@ func (l *LifecycleManager) addFinalizersIfNeeded(ctx context.Context, instance R
 		}
 	}
 	if update {
-		err := l.client.Update(ctx, instance)
+		patch := client.MergeFrom(original)
+		err := l.client.Patch(ctx, instance, patch)
 		if err != nil {
 			return err
 		}
@@ -401,6 +403,7 @@ func (l *LifecycleManager) removeFinalizerIfNeeded(ctx context.Context, instance
 
 	if !result.Requeue && result.RequeueAfter == 0 {
 		update := false
+		original := instance.DeepCopyObject().(client.Object)
 		for _, f := range subroutine.Finalizers() {
 			needsUpdate := controllerutil.RemoveFinalizer(instance, f)
 			if needsUpdate {
@@ -408,7 +411,8 @@ func (l *LifecycleManager) removeFinalizerIfNeeded(ctx context.Context, instance
 			}
 		}
 		if update {
-			err := l.client.Update(ctx, instance)
+			patch := client.MergeFrom(original)
+			err := l.client.Patch(ctx, instance, patch)
 			if err != nil {
 				return errors.NewOperatorError(errors.Wrap(err, "failed to update instance"), true, false)
 			}

--- a/controller/testSupport/client.go
+++ b/controller/testSupport/client.go
@@ -15,6 +15,7 @@ func CreateFakeClient(t *testing.T, objects ...client.Object) client.WithWatch {
 	builder := fake.NewClientBuilder()
 	s := runtime.NewScheme()
 	sBuilder := scheme.Builder{GroupVersion: schema.GroupVersion{Group: "test.openmfp.io", Version: "v1alpha1"}}
+	sBuilder.Register(&TestApiObject{})
 	for _, obj := range objects {
 		sBuilder.Register(obj)
 		builder.WithStatusSubresource(obj)


### PR DESCRIPTION
#176 

Use PATCH for finalizer updates

- Capture a DeepCopy of the object as `original` before mutating finalizers.
- Replace client.Update calls with client.Patch to only modify the finalizers field.
- Register TestApiObject in the fake client’s scheme so GVK lookups succeed in lifecycle tests.

Testing:
`task test`